### PR TITLE
Update README with an example use of sqlformat-command and sqlformat-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,16 @@ then `(require 'sqlformat)`.
 Usage
 =====
 
-Customise the `sqlformat-command` variable as desired, then call
-`sqlformat`, `sqlformat-buffer` or `sqlformat-region` as convenient.
+Customise the `sqlformat-command` variable as desired. For example, to
+use [pgformatter][pgformatter] (i.e., the `pg_format` command) with
+two-character indent and no statement grouping,
+
+``` el
+(setq sqlformat-command 'pgformatter)
+(setq sqlformat-args '("-s2" "-g"))
+```
+
+Then call `sqlformat`, `sqlformat-buffer` or `sqlformat-region` as convenient.
 
 Enable `sqlformat-on-save-mode` in SQL buffers like this:
 

--- a/sqlformat.el
+++ b/sqlformat.el
@@ -29,8 +29,15 @@
 ;; Install the "sqlparse" (Python) package to get "sqlformat", or
 ;; "pgformatter" to get "pg_format".
 
-;; Customise the `sqlformat-command' variable as desired, then call
-;; `sqlformat', `sqlformat-buffer' or `sqlformat-region' as convenient.
+;; Customise the `sqlformat-command' variable as desired. For example,
+;; to use "pgformatter" (i.e., the `pg_format` command) with
+;; two-character indent and no statement grouping,
+
+;;     (setq sqlformat-command 'pgformatter)
+;;     (setq sqlformat-args '("-s2" "-g"))
+
+;; Then call `sqlformat', `sqlformat-buffer' or `sqlformat-region' as
+;; convenient.
 
 ;; Enable `sqlformat-on-save-mode' in SQL buffers like this:
 


### PR DESCRIPTION
This PR updates README and the source comment with an example use of `sqlformat-command` and `sqlformat-args`, which are not explained outside the source code itself. Providing an example would help users so that they do not have to read the source code.