### PR TITLE
Fixed order of args passed to sqlfluff

### DIFF
--- a/sqlformat.el
+++ b/sqlformat.el
@@ -92,7 +92,7 @@ For example these options may be useful for sqlformat command: '(\"-k\" \"upper\
   :args (pcase sqlformat-command
           (`sqlformat  (append sqlformat-args '("-r" "-")))
           (`pgformatter (append sqlformat-args '("-")))
-          (`sqlfluff (append sqlformat-args '("fix" "-f" "-"))))
+          (`sqlfluff (append '("fix") sqlformat-args '("-f" "-")))
   :lighter " SQLFmt"
   :group 'sqlformat)
 


### PR DESCRIPTION
W/o patch, the user receives an error when trying to pass additional args to sqlfluff using the sql-format-args variable.  See this example configuration:

`(use-package sqlformat
  :ensure t
  :config
  (setq sqlformat-command 'sqlfluff)
  (setq sqlformat-args '("-v"))
  )`

I believe the intent of sqlformat is to pass the args to sqlfluff like this: 'sqlfluff **fix** [args go here]'.  With the patch, this is how the args get passed. Without the patch, the args are passed like this: 'sqlfluff [args go here] **fix**'. 

Perhaps a better solution would be to allow for both? I'll let you weigh in on that. 
