### PR TITLE
Empty string returned to buffer

### DIFF
--- a/sqlformat.el
+++ b/sqlformat.el
@@ -92,7 +92,7 @@ For example these options may be useful for sqlformat command: '(\"-k\" \"upper\
   :args (pcase sqlformat-command
           (`sqlformat  (append sqlformat-args '("-r" "-")))
           (`pgformatter (append sqlformat-args '("-")))
-          (`sqlfluff (append '("fix") sqlformat-args '("-f" "-"))))
+          (`sqlfluff (append '("fix") sqlformat-args '("-f"))))
   :lighter " SQLFmt"
   :group 'sqlformat)
 


### PR DESCRIPTION
After the execution of sqlformat the sql buffer was set to empty

This is due to existance of the parameter "-" on sqlformat-args.

Testing this command we get:

$ sqlfluff fix temp.sql --dialect ansi -f -
==== finding fixable violations ====
== [apagar.sql] FAIL
L:   1 | P:   1 | L036 | Select targets should be on a new line unless there is
                       | only one select target.
L:   1 | P:  10 | L008 | Commas should be followed by a single whitespace unless
                       | followed by a comment.
L:   1 | P:  12 | L008 | Commas should be followed by a single whitespace unless
                       | followed by a comment.
The path(s) ('temp.sql', '-') could not be accessed. Check it/they exist(s).

This issue ocurred on Windows and Linux. Not sure if it also happens on Mac. I lack the access to one to test.