### PR TITLE
Use correct sqlfluff command

### DIFF
--- a/sqlformat.el
+++ b/sqlformat.el
@@ -94,7 +94,7 @@ For example these options may be useful for sqlformat command: '(\"-k\" \"upper\
   :args (pcase sqlformat-command
           (`sqlformat  (append sqlformat-args '("-r" "-")))
           (`pgformatter (append sqlformat-args '("-")))
-          (`sqlfluff (append '("fix") sqlformat-args '("-f" "-")))
+          (`sqlfluff (append '("format") sqlformat-args '("-")))
           (`sql-formatter sqlformat-args))
   :lighter " SQLFmt"
   :group 'sqlformat)


### PR DESCRIPTION
SQLFluff should be called with `format`, which applies only formatting rules, not `fix`, which also makes other changes.

See: https://docs.sqlfluff.com/en/stable/cli.html#sqlfluff-format
vs. https://docs.sqlfluff.com/en/stable/cli.html#sqlfluff-fix and in particular the note that `fix` with `-f/--force` should be used with caution: https://docs.sqlfluff.com/en/stable/cli.html#cmdoption-sqlfluff-fix-f